### PR TITLE
correct typo inside an url

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you'd like to change the theme's HTML layout:
 
 ## Roadmap
 
-See the [open issues](https://github.com/pagse-themes/hacker/issues) for a list of proposed features (and known issues).
+See the [open issues](https://github.com/pages-themes/hacker/issues) for a list of proposed features (and known issues).
 
 ## Project philosophy
 


### PR DESCRIPTION
Otherwise, link won’t work.