### PR TITLE
Removed css properties with unneeded prefix.

### DIFF
--- a/_sass/jekyll-theme-hacker.scss
+++ b/_sass/jekyll-theme-hacker.scss
@@ -158,8 +158,6 @@ pre {
   font-size: 16px;
   color: #b5e853;
   border-radius: 2px;
-  -moz-border-radius: 2px;
-  -webkit-border-radius: 2px;
   text-wrap: normal;
   overflow: auto;
   overflow-y: hidden;


### PR DESCRIPTION
I am using Firefox 45.6.0 ESR and I get the console error

    Unknown property '-moz-border-radius'. Declaration ignored.            style.css:106:169

So I removed the unneeded prefixes. According to [caniuse.com](http://caniuse.com/#search=border-radius) `border-radius` has been supported for ages (even IE), so I think its safe to drop those.