### PR TITLE
CSS: Add highlighting for inline keywords

### DIFF
--- a/_sass/jekyll-theme-hacker.scss
+++ b/_sass/jekyll-theme-hacker.scss
@@ -163,6 +163,15 @@ pre {
   overflow-y: hidden;
 }
 
+code.highlighter-rouge {
+  background: rgba(0,0,0,0.9);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 0px 3px;
+  margin: 0px -3px;
+  color: #aa759f;
+  border-radius: 2px;
+}
+
 table {
   width: 100%;
   margin: 0 0 20px 0;

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-Text can be **bold**, _italic_, or ~~strikethrough~~.
+Text can be **bold**, _italic_, ~~strikethrough~~ or `keyword`.
 
 [Link to another page](another-page).
 


### PR DESCRIPTION
Managed to figure out #10 after all.

I'm no expert in CSS, but I came up with a working solution to add highlighting to `keywords`. If there's a better way to do it, let me know.