### PR TITLE
created blank layout and modified posts layout to inherit from blank

### DIFF
--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+{% seo %}
+  </head>
+
+  <body>
+
+    <header>
+      <div class="container">
+        <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        <h2>{{ site.description | default: site.github.project_tagline }}</h2>
+      </div>
+    </header>
+
+    <div class="container">
+      <section id="main_content">
+        {{ content }}
+      </section>
+    </div>
+
+    {% if site.google_analytics %}
+      <script type="text/javascript">
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '{{ site.google_analytics }}', 'auto');
+        ga('send', 'pageview');
+      </script>
+    {% endif %}
+  </body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: blank
 ---
 
 <small>{{ page.date | date: "%-d %B %Y" }}</small>


### PR DESCRIPTION
This is what a blog post would look like with the default theme:
![default](https://user-images.githubusercontent.com/7058329/38264288-87e89ad4-3740-11e8-945a-7f1ca6e0689e.PNG)

I made a post layout that would allow them to look more like a blog post. Unfortunately, since the default layout has the links and the post layout inherited from that, the links stayed as such:
![postfromdefault](https://user-images.githubusercontent.com/7058329/38264356-b7a5b9f0-3740-11e8-9eb0-f0d6e90f69d0.PNG)

I've now created a new layout called 'blank' which the post layout now extends from. This allows you to create a page without the github pages/project links in the header:
![post](https://user-images.githubusercontent.com/7058329/38264407-dd5f1d08-3740-11e8-975b-fad015afc92e.PNG)

This will also allow you to create regular pages without the same links in the header, as such:
![1blank](https://user-images.githubusercontent.com/7058329/38264449-040e414a-3741-11e8-8c5d-385e2f1d629f.PNG)


I believe creating a blank layout to build from this way will maintain the "simplicity" of the project philosophy while adding "flexibility" for users to create: landing pages for their github projects, periodic posts, and regular web pages (without project links attached). I believe this will satisfy the last half of issue #20 