### PR TITLE
Add the ability to hide github link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 title: Hacker theme
 description: Hacker is a theme for GitHub Pages.
 show_downloads: true
+show_github: true
 google_analytics:
 theme: jekyll-theme-hacker

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,9 @@
             <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>
             <a href="{{ site.github.tar_url }}" class="btn">Download as .tar.gz</a>
           {% endif %}
+          {% if site.show_github %}
           <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
+          {% endif %}
         </section>
       </div>
     </header>


### PR DESCRIPTION
For a static site (such as blog) the github url is not relevant