### PR TITLE
fixed word break

### DIFF
--- a/_sass/jekyll-theme-hacker.scss
+++ b/_sass/jekyll-theme-hacker.scss
@@ -167,6 +167,7 @@ code.highlighter-rouge {
   margin: 0px -3px;
   color: #aa759f;
   border-radius: 2px;
+  word-break: break-all;
 }
 
 table {


### PR DESCRIPTION
主题样式在现代手机上会出现因链接过长而无法换行导致的整个宽度超出bug, 已经提交,请合并一下.