### PR TITLE
Disable "View on Github" button

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,9 @@
             <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>
             <a href="{{ site.github.tar_url }}" class="btn">Download as .tar.gz</a>
           {% endif %}
+          {% if site.github.is_project_page %}
           <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
+          {% endif %}
         </section>
       </div>
     </header>


### PR DESCRIPTION
Add a option to disable a "View on Github" button. 

To disable, add this option

```yml
github:
  is_project_page: false
```

in your _config.yml file