### PR TITLE
Show full header h1 for smaller displays

### DIFF
--- a/_sass/jekyll-theme-hacker.scss
+++ b/_sass/jekyll-theme-hacker.scss
@@ -6,6 +6,13 @@ $body-foreground: $gallery !default;
 $header: $conifer !default;
 $blockquote-color: $silver-chalice !default;
 $blockquote-border: $dove-grey !default;
+$container-max-width: 1000px;
+
+@mixin media-max-width($max-width) {
+  @media (max-width: $max-width) {
+      @content;
+  }
+}
 
 body {
   margin: 0;
@@ -21,7 +28,7 @@ body {
 
 .container {
   width: 90%;
-  max-width: 1000px;
+  max-width: $container-max-width;
   margin: 0 auto;
 }
 
@@ -64,7 +71,11 @@ header h1 {
                0 0 10px rgba(181, 232, 83, 0.1);
   letter-spacing: -1px;
   -webkit-font-smoothing: antialiased;
+  @include media-max-width($container-max-width) {
+    margin-left: 0;
+  }
 }
+
 
 header h1:before {
   content: "./ ";


### PR DESCRIPTION
The header h1 before "./ " would be lost in mobile displays and/or when the browser viewport is smaller than the container width as the header has negative left margin for the "./ " text.

This pr removes the left margin from the header for smaller displays. Also adds a scss variable
so that its easy to change the point where the margin is applied.

Before:

![before](https://user-images.githubusercontent.com/1352132/73167874-55e40100-4101-11ea-80e4-7ea8ff09c260.png)

And with longer header text even the next line of the header is too much on the left:

![image](https://user-images.githubusercontent.com/1352132/73168081-cb4fd180-4101-11ea-91a5-5e5150749720.png)


After:

![after](https://user-images.githubusercontent.com/1352132/73167882-5c727880-4101-11ea-8249-49a9f4d7d103.png)

And with longer header text:

![image](https://user-images.githubusercontent.com/1352132/73168120-de62a180-4101-11ea-9352-4d3aa8375220.png)


Does not affect the layout if window size is larger than container max-width.

![image](https://user-images.githubusercontent.com/1352132/73168140-ea4e6380-4101-11ea-98c1-7ccdc18de0ee.png)
