### PR TITLE
Add support for Google gtags (Google Analytics v4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Additionally, you may choose to set the following optional variables:
 ```yml
 show_downloads: ["true" or "false" to indicate whether to provide a download URL]
 google_analytics: [Your Google Analytics tracking ID]
+google_analytics_v4: [Your Google Analytics v4 (gtags) tracking ID]
 ```
+
+`google_analytics` and `google_analytics_v4` are incompatible, you have to choose one of them, if both are set the later takes precedence.
 
 ### Stylesheet
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     {% if site.google_analytics_v4 %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_v4 }}"></script>
@@ -12,9 +15,6 @@
       gtag('config', '{{ site.google_analytics_v4 }}');
     </script>
     {% endif %}
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
 
 {% seo %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,17 @@
 <!DOCTYPE html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
+    {% if site.google_analytics_v4 %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_v4 }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '{{ site.google_analytics_v4 }}');
+    </script>
+    {% endif %}
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -35,6 +46,7 @@
     </div>
 
     {% if site.google_analytics %}
+      {% unless site.google_analytics_v4 %}
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -43,6 +55,7 @@
         ga('create', '{{ site.google_analytics }}', 'auto');
         ga('send', 'pageview');
       </script>
+      {% endunless %}
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
With this pull request will be support for Google Analytics v4 by using the google_analytics_v4 variable in _config.yml. 

Old Google Analytics (analytics.js) is still supported by means of google_analytics variable but v4 takes precedence if both variables are set.

This pull request should address issue #63.