### PR TITLE
Supports switch on "view on github" link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
               <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>
               <a href="{{ site.github.tar_url }}" class="btn">Download as .tar.gz</a>
             {% endif %}
+
             {% if site.github.is_project_page %}
               <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
             {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,13 +20,15 @@
         <h2>{{ site.description | default: site.github.project_tagline }}</h2>
 
         {% if site.show_downloads or site.github.is_project_page %}
-        <section id="downloads">
-          {% if site.show_downloads %}
-            <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>
-            <a href="{{ site.github.tar_url }}" class="btn">Download as .tar.gz</a>
-          {% endif %}
-          {% if site.github.is_project_page %}<a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>{% endif %}
-        </section>
+          <section id="downloads">
+            {% if site.show_downloads %}
+              <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>
+              <a href="{{ site.github.tar_url }}" class="btn">Download as .tar.gz</a>
+            {% endif %}
+            {% if site.github.is_project_page %}
+              <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
+            {% endif %}
+          </section>
         {% endif %}
       </div>
     </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,13 +19,15 @@
         </a>
         <h2>{{ site.description | default: site.github.project_tagline }}</h2>
 
+        {% if site.show_downloads or site.github.is_project_page %}
         <section id="downloads">
           {% if site.show_downloads %}
             <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>
             <a href="{{ site.github.tar_url }}" class="btn">Download as .tar.gz</a>
           {% endif %}
-          <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
+          {% if site.github.is_project_page %}<a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>{% endif %}
         </section>
+        {% endif %}
       </div>
     </header>
 


### PR DESCRIPTION
Implements feature #61 using github config metadata gem to be compatible with the other page-themes

![Screenshot_20210808-075119](https://user-images.githubusercontent.com/3125580/128622364-bf132f01-70fc-4aa0-879f-cfa6cd3a4b56.png)

Also related with #45 #42 #26 #25 #16 #14 #3

Resolves #61, resolves #45, resolves #42, resolves #26, resolves #25, resolves #16, resolves #14, resolves #3