### PR TITLE
Add styles for tasklist

### DIFF
--- a/_sass/jekyll-theme-hacker.scss
+++ b/_sass/jekyll-theme-hacker.scss
@@ -153,6 +153,43 @@ ul li {
   list-style-image:url('../images/bullet.png');
 }
 
+ul.task-list {
+  $checkbox-size: 1em;
+  
+  list-style: none;
+  padding-left: 0.5em;
+
+  li.task-list-item {
+    list-style-image: none;
+    position: relative;
+
+    input.task-list-item-checkbox {
+      display: inline-block;
+      margin-right: 1.2em;
+      width: $checkbox-size;
+      height: $checkbox-size;
+      vertical-align: middle;
+      -webkit-appearance: none;
+         -moz-appearance: none;
+           -o-appearance: none;
+              appearance: none;
+      -webkit-box-shadow: none;
+         -moz-box-shadow: none;
+           -o-box-shadow: none;
+              box-shadow: none;
+      outline: $checkbox-size*0.2 solid $conifer;
+
+      &:checked {
+        width: $checkbox-size*0.813;
+        height: $checkbox-size*0.813;
+        margin-left: $checkbox-size*0.35;
+        outline: $checkbox-size*0.35 double adjust-color($conifer, $lightness: 0%);
+        background-color: adjust-color($conifer, $lightness: -20%);
+      }
+    }
+  }
+}
+
 blockquote {
   color: $blockquote-color;
   padding-left: 10px;

--- a/index.md
+++ b/index.md
@@ -92,6 +92,11 @@ end
   - level 2 item
 - level 1 item
 
+### What about task lists...
+
+- [ ] Undone task (unchecked)
+- [x] Completed task (checked)
+
 ### Small image
 
 ![Octocat](https://github.githubassets.com/images/icons/emoji/octocat.png)


### PR DESCRIPTION
Generate styles for tasklist preserving theme colors

![image](https://user-images.githubusercontent.com/7142231/126001302-35ea0005-6b4e-42e7-9b49-a6b423712aeb.png)
to
![image](https://user-images.githubusercontent.com/3125580/131437594-363cfd84-b841-4a93-b0aa-dae45f232c4b.png)

A complete implement for pages-themes/hacker#75. Resolves #75 

Preview a demo at https://davorpa.github.io/github-pages-themes-hacker/#what-about-task-lists