### PR TITLE
fix: favicon link

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -7,6 +7,6 @@
 {% include head-custom-google-analytics.html %}
 
 <!-- You can set your favicon here -->
-<!-- link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}" -->
+<!-- <link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}"/> -->
 
 <!-- end custom head snippets -->


### PR DESCRIPTION
fix link to a correct html tag when doing this line uncomment uses editor shortcut

