### PR TITLE
Fixes the large image link on the demo homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://guides.github.com/activities/hello-world/branching.png)
+![Branching](https://docs.github.com/assets/cb-23923/mw-1440/images/help/repository/branching.webp)
 
 
 ### Definition lists can be used with HTML syntax.


### PR DESCRIPTION
Fixes #171

Before:

<img width="207" alt="Before" src="https://github.com/user-attachments/assets/447304c9-0619-42cc-bb3a-6e40075c6d10">

After:

<img width="1036" alt="After" src="https://github.com/user-attachments/assets/a2de9e9a-4d55-43db-a3a7-98abd4d417d3">

